### PR TITLE
Fix for PDL 2.073+

### DIFF
--- a/CCS/Nd.pm
+++ b/CCS/Nd.pm
@@ -569,7 +569,7 @@ BEGIN { *_whichVals = \&_nzvals; }
 sub _nzvals :lvalue {
   my ($tmp);
   $_[0][$VALS]=$_[1]->append($_[0][$VALS]->slice("-1")) if (@_ > 1);
-  return $tmp=$_[0][$VALS]->index(PDL->null) if ($_[0][$VALS]->dim(0)<=1);
+  return $tmp=$_[0][$VALS]->index(PDL->zeroes(ccs_indx(), 0)) if ($_[0][$VALS]->dim(0)<=1);
   return $tmp=$_[0][$VALS]->slice("0:-2");
 }
 

--- a/CCS/Nd.pm
+++ b/CCS/Nd.pm
@@ -3197,7 +3197,7 @@ Get/set the underlying $WHICH piddle.
 
 =item _nzvals($storedvals)
 
-Get/set the slice of the underlying $VALS piddle correpsonding for non-missing values only.
+Get/set the slice of the underlying $VALS piddle corresponding for non-missing values only.
 Alias: whichVals().
 
 

--- a/CCS/Nd.pm
+++ b/CCS/Nd.pm
@@ -1193,7 +1193,7 @@ sub _ufunc_ind_sub {
 			     pdims =>$newdims,
 			     vdims =>$newdims->sequence,
 			     which =>$which2,
-			     vals  =>$nzi2->append(-1),
+			     vals  =>$nzi2->append(ccs_indx(-1)),
 			    );
   };
 }
@@ -1239,7 +1239,7 @@ sub qsorti :lvalue {
 			      pdims =>$newdims,
 			      vdims =>$newdims->sequence,
 			      which =>$nzenum->slice("*1,")->glue(0,$which0->slice("1:-1,")->dice_axis(1,$nzix)),
-			      vals  =>$which0->slice("(0),")->index($nzix)->append(-1),
+			      vals  =>$which0->slice("(0),")->index($nzix)->append(ccs_indx(-1)),
 			     );
 }
 

--- a/CCS/Nd.pm
+++ b/CCS/Nd.pm
@@ -414,6 +414,7 @@ sub todense  :lvalue { isa($_[0],__PACKAGE__) ? (my $tmp=$_[0]->decode(@_[1..$#_
 
 ## $type = $obj->type()
 sub type { $_[0][$VALS]->type; }
+sub info { $_[0][$VALS]->info; }
 
 ## $obj2 = $obj->convert($type)
 ##  + unlike PDL function, respects 'inplace' flag

--- a/CCS/t/03_ufuncs.t
+++ b/CCS/t/03_ufuncs.t
@@ -63,7 +63,9 @@ sub test_ufunc {
   ##-- check output type
  SKIP: {
     skip("${label}:type - only for PDL >= v2.014",1) if (!$HAVE_PDL_2_014);
-    isok("${label}:type", $ccs_rc->type, $dense_rc->type);
+    isok("${label}:type", $ccs_rc->type, $dense_rc->type)
+      or diag "ccs_rc(", $ccs_rc->info, ")=$ccs_rc\n",
+      "dense_rc(", $dense_rc->info, ")=$dense_rc\n";
   }
 
   ##-- check output values

--- a/t/common.plt
+++ b/t/common.plt
@@ -6,6 +6,7 @@ use strict;
 
 # isok($label,@_) -- prints helpful label
 sub isok {
+  local $Test::Builder::Level = $Test::Builder::Level + 1;
   my $label = shift;
   if (@_==1) {
     ok($_[0],$label);
@@ -19,6 +20,7 @@ sub isok {
 # skipok($label,$skip_if_true,@_) -- prints helpful label
 # skipok($label,$skip_if_true,\&CODE) -- prints helpful label
 sub skipok {
+  local $Test::Builder::Level = $Test::Builder::Level + 1;
   my ($label,$skip_if_true) = splice(@_,0,2);
   if ($skip_if_true) {
     subtest $label => sub { plan skip_all => $skip_if_true; };
@@ -33,6 +35,7 @@ sub skipok {
 
 # skipordo($label,$skip_if_true,sub { ok ... },@args_for_sub)
 sub skipordo {
+  local $Test::Builder::Level = $Test::Builder::Level + 1;
   my ($label,$skip_if_true) = splice(@_,0,2);
   if ($skip_if_true) {
     subtest $label => sub { plan skip_all => $skip_if_true; };
@@ -44,6 +47,7 @@ sub skipordo {
 # ulistok($label,\@got,\@expect)
 # --> ok() for unsorted lists
 sub ulistok {
+  local $Test::Builder::Level = $Test::Builder::Level + 1;
   my ($label,$l1,$l2) = @_;
   is_deeply([sort @$l1],[sort @$l2],$label);
 }
@@ -83,6 +87,7 @@ sub labstr {
 
 # pdlok($label, $got, $want)
 sub pdlok {
+  local $Test::Builder::Level = $Test::Builder::Level + 1;
   my ($label,$got,$want) = @_;
   $got  = PDL->topdl($got) if (defined($got));
   $want = PDL->topdl($want) if (defined($want));
@@ -96,6 +101,7 @@ sub pdlok {
 # pdlok_nodims($label, $got, $want)
 #  + ignores dimensions
 sub pdlok_nodims {
+  local $Test::Builder::Level = $Test::Builder::Level + 1;
   my ($label,$got,$want) = @_;
   $got  = PDL->topdl($got) if (defined($got));
   $want = PDL->topdl($want) if (defined($want));
@@ -107,6 +113,7 @@ sub pdlok_nodims {
 
 # pdlapprox($label, $got, $want, $eps=1e-5)
 sub pdlapprox {
+  local $Test::Builder::Level = $Test::Builder::Level + 1;
   my ($label,$got,$want,$eps) = @_;
   $got  = PDL->topdl($got) if (defined($got));
   $want = PDL->topdl($want) if (defined($want));


### PR DESCRIPTION
These ought to be backwards compatible. There were two problems:
- `Primitive::append($indx_pdl, -1)` started returning a `double` pdl, which I have fixed in PDL master but also backwards-compatibly fixed here so it works with PDL 2.073-4.
- `CCS::Nd::_nzvals` was calling `Slices::index` with a `null`. This is now an error in PDL and I stand by that being correct. I have replaced it in your code with a `zeroes(ccs_indx(), 0)` (i.e. an empty ndarray) since I assume that is what you intended.

There are also minor fixups like test failure location-reporting, typo fixes, and a `CCS::Nd->info` method which I found useful in test error-reporting.