### PR TITLE
no strict "refs" instead of string-eval

### DIFF
--- a/CCS/Compat.pm
+++ b/CCS/Compat.pm
@@ -832,7 +832,8 @@ sub ccs_binop_compat_cv {
   return sub { $ccsop->(@_[1,2,3,4]) };
 }
 foreach my $op (@ccs_binops) {
-  eval "*ccs${op}_cv = *PDL::ccs${op}_cv = ccs_binop_compat_cv(\\&PDL::ccs_${op}_vector_mia);";
+  no strict 'refs';
+  *{"ccs${op}_cv"} = *{"PDL::ccs${op}_cv"} = ccs_binop_compat_cv(\&{"PDL::ccs_${op}_vector_mia"});
 }
 *ccsadd_cv = *PDL::ccsadd_cv = \&ccsplus_cv;
 *ccsdiff_cv = *PDL::ccsdiff_cv = \&ccsminus_cv;
@@ -869,7 +870,8 @@ sub ccs_binop_compat_rv {
   };
 }
 foreach my $op (@ccs_binops) {
-  eval "*ccs${op}_rv = *PDL::ccs${op}_rv = ccs_binop_compat_rv(\\&PDL::ccs_${op}_vector_mia);";
+  no strict 'refs';
+  *{"ccs${op}_rv"} = *{"PDL::ccs${op}_rv"} = ccs_binop_compat_rv(\&{"PDL::ccs_${op}_vector_mia"});
 }
 *ccsadd_rv = *PDL::ccsadd_rv = \&ccsplus_rv;
 *ccsdiff_rv = *PDL::ccsdiff_rv = \&ccsminus_rv;

--- a/CCS/Nd.pm
+++ b/CCS/Nd.pm
@@ -431,8 +431,9 @@ sub _pdltype_sub {
   return sub { return $pdltype if (!@_); convert(@_,$pdltype); };
 }
 foreach my $pdltype (map {$_->{convertfunc}} values %PDL::Types::typehash) {
+  no strict 'refs';
   #qw(byte short ushort long longlong indx float double)
-  eval "*${pdltype} = _pdltype_sub(PDL::${pdltype}());";
+  *$pdltype = _pdltype_sub("PDL::${pdltype}"->());
 }
 
 ## $dimpdl = $obj->dimpdl()
@@ -720,7 +721,8 @@ sub _setbad_sub {
 
 ## $obj = $obj->setnantobad()
 foreach my $badsub (qw(setnantobad setbadtonan setbadtoval setvaltobad)) {
-  eval "*${badsub} = _setbad_sub(PDL->can('$badsub'));";
+  no strict 'refs';
+  *$badsub = _setbad_sub(PDL->can($badsub));
 }
 
 ##--------------------------------------------------------------
@@ -1096,11 +1098,13 @@ foreach my $ufunc (
 		   qw(and or band bor),
 		  )
   {
-    eval "*${ufunc}over = _ufuncsub('${ufunc}over', PDL::CCS::Ufunc->can('ccs_accum_${ufunc}'))";
+    no strict 'refs';
+    *{"${ufunc}over"} = _ufuncsub("${ufunc}over", PDL::CCS::Ufunc->can("ccs_accum_${ufunc}"));
   }
 foreach my $ufunc (qw(maximum minimum average))
   {
-    eval "*${ufunc} = _ufuncsub('${ufunc}', PDL::CCS::Ufunc->can('ccs_accum_${ufunc}'))";
+    no strict 'refs';
+    *$ufunc = _ufuncsub($ufunc, PDL::CCS::Ufunc->can("ccs_accum_${ufunc}"));
   }
 
 *nbadover  = _ufuncsub('nbadover',  PDL::CCS::Ufunc->can('ccs_accum_nbad'), 1);
@@ -1261,7 +1265,8 @@ sub _unary_op {
 
 foreach my $unop (qw(bitnot sqrt abs sin cos not exp log log10))
   {
-    eval "*${unop} = _unary_op('${unop}',PDL->can('${unop}'));";
+    no strict 'refs';
+    *$unop = _unary_op($unop,PDL->can($unop));
   }
 
 ##--------------------------------------------------------------
@@ -1709,7 +1714,8 @@ foreach my $binop (
 		   qw(gt ge lt le eq ne spaceship),
 		  )
   {
-    eval "*${binop} = *${binop}_mia = _ccsnd_binary_op_mia('${binop}',PDL->can('${binop}'));";
+    no strict 'refs';
+    *$binop = *{"${binop}_mia"} = _ccsnd_binary_op_mia($binop,PDL->can($binop));
     die(__PACKAGE__, ": could not define binary operation $binop: $@") if ($@);
   }
 
@@ -1721,7 +1727,8 @@ foreach my $intop (
 		  )
   {
     my $deftype = PDL->can($intop)->(PDL->pdl(0),PDL->pdl(0),0)->type->ioname;
-    eval "*${intop} = *${intop}_mia = _ccsnd_binary_op_mia('${intop}',PDL->can('${intop}'),PDL::${deftype}());";
+    no strict 'refs';
+    *$intop = *{"${intop}_mia"} = _ccsnd_binary_op_mia($intop,PDL->can($intop),"PDL::${deftype}"->());
     die(__PACKAGE__, ": could not define integer operation $intop: $@") if ($@);
   }
 


### PR DESCRIPTION
Just adding checks to PDL to make it not broadcast over outputs, and it caused your `t/06_matops.t` to fail. It turns out this is only a problem in PDL, but while looking into it I noticed CCS has string-evals and I thought I'd PR these modest changes.