### PR TITLE
switch from $PP() to $P() which physicalises in all PDL even pre-2.0

### DIFF
--- a/CCS/Utils/ccsutils.pd
+++ b/CCS/Utils/ccsutils.pd
@@ -315,7 +315,7 @@ pp_def('ccs_pointerlen',
 
        Code =>
 q{
-   $GENERIC(ptr) *pptr = $PP(ptr);
+   $GENERIC(ptr) *pptr = $P(ptr);
    loop (N) %{
      $ptrlen() = *(pptr+1) - *pptr;
      ++pptr;


### PR DESCRIPTION
The `$PP()` macro is a misfeature that dodged the vaffine optimisation (which has never really worked right and still doesn't very well). Using the `$P()` macro instead achieves exactly the same, but also physicalises that pdl, which your code relies on to have contiguous data.

Also, the operation this modifies has a `PMCode` which simply achieves the same as a `RedoDimsCode` that has access to setting a `$SIZE` based on a different one, available since 2.075, over two years ago. Are you open to updating your minimum PDL to that?