### PR TITLE
`ccs_pointerlen` removal

### DIFF
--- a/CCS/Functions.pm
+++ b/CCS/Functions.pm
@@ -21,7 +21,7 @@ our @EXPORT_OK =
   (
    ##
    ##-- Decoding
-   qw(ccs_decode ccs_pointerlen),
+   qw(ccs_decode),
    ##
    ##-- Vector Operations (compat)
    qw(ccs_binop_vector_mia),
@@ -62,38 +62,6 @@ PDL::CCS::Functions - Useful perl-level functions for PDL::CCS
 =head1 Decoding
 
 =cut
-
-##---------------------------------------------------------------
-## Decoding: utils
-=pod
-
-=head2 ccs_pointerlen
-
-=for sig
-
-  Signature: (indx ptr(N+1); indx [o]len(N))
-
-Get number of non-missing values for each axis value from a CCS-encoded
-offset pointer vector $ptr().
-
-=cut
-
-;#-- emacs
-
-*ccs_pointerlen = \&PDL::ccs_pointerlen; 
-
-##-- now a PDL::PP function in PDL::CCS::Utils
-*PDL::ccs_pointerlen_perl = \&ccs_pointerlen_perl;
-sub ccs_pointerlen_perl :lvalue {
-  my ($ptr,$len) = @_;
-  if (!defined($len)) {
-    $len = $ptr->slice("1:-1") - $ptr->slice("0:-2");
-  } else {
-    $len .= $ptr->slice("1:-1");
-    $len -= $ptr->slice("0:-2");
-  }
-  return $len;
-}
 
 ##---------------------------------------------------------------
 ## Decoding: generic

--- a/CCS/Nd.pm
+++ b/CCS/Nd.pm
@@ -6,7 +6,7 @@ package PDL::CCS::Nd;
 use PDL::Lite qw();
 use PDL::VectorValued;
 use PDL::CCS::Config qw(ccs_indx);
-use PDL::CCS::Functions qw(ccs_decode ccs_pointerlen ccs_qsort);
+use PDL::CCS::Functions qw(ccs_decode ccs_qsort);
 use PDL::CCS::Utils     qw(ccs_encode_pointers ccs_decode_pointer);
 use PDL::CCS::Ufunc;
 use PDL::CCS::Ops;

--- a/CCS/Utils/ccsutils.pd
+++ b/CCS/Utils/ccsutils.pd
@@ -307,41 +307,6 @@ If unspecified, $proj() defaults to:
 EOD
 );
 
-##--------------------------------------------------------------
-## _ccs_pointerlen : optimized pointer-length
-pp_def('ccs_pointerlen',
-       Pars => "ptr(Nplus1); [o]ptrlen(N);",
-       GenericTypes=>$PDL::CCS::Config::ccsConfig{INT_TYPE_CHRS},
-
-       Code =>
-q{
-   $GENERIC(ptr) *pptr = $P(ptr);
-   loop (N) %{
-     $ptrlen() = *(pptr+1) - *pptr;
-     ++pptr;
-   %}
-},
-
-       PMCode =>
-q{
-sub PDL::ccs_pointerlen {
-  my ($ptr,$len) = @_;
-  $len = zeroes($ptr->type, $ptr->nelem-1) if (!defined($len));
-  &PDL::_ccs_pointerlen_int($ptr,$len);
-  return $len;
-}
-},
-
-       Doc => <<'EOD'
-
-Get number of non-missing values for each axis value from a CCS-encoded
-offset pointer vector $ptr().
-
-EOD
-      ); ##-- /ccs_pointerlen
-
-
-
 ##======================================================================
 ## Indexing
 ##======================================================================

--- a/CCS/t/03_ufuncs.t
+++ b/CCS/t/03_ufuncs.t
@@ -70,7 +70,7 @@ sub test_ufunc {
 
   ##-- check output values
  SKIP: {
-    ##-- RT bug #126294 (ses also analogous tests in CCS/Ufunc/t/01_ufunc.t)
+    ##-- RT bug #126294 (see also analogous tests in CCS/Ufunc/t/01_ufunc.t)
     skip("RT #126294 - PDL::borover() appears to be broken", 1)
       if ($label eq 'borover:missing=BAD' && pdl([10,0,-2])->setvaltobad(0)->borover->sclr != -2);
 


### PR DESCRIPTION
This executes the `RedoDimsCode` change discussed in #9.

Going a bit further (though not in this thing), I can't actually see the function being used at all? I added a test for it here for completeness, but when I deliberately broke it by deleting the body of the loop, everything else still passed. Can it just be deleted entirely?