### PR TITLE
CCS/t/03_ufuncs.t assign data of correct type

### DIFF
--- a/CCS/t/03_ufuncs.t
+++ b/CCS/t/03_ufuncs.t
@@ -52,11 +52,11 @@ sub test_ufunc {
 
   if ($ufunc_name =~ /_ind$/) {
     ##-- hack: adjust $dense_rc for maximum_ind, minimum_ind
-    $dense_rc->where( $a->index2d($dense_rc,sequence($a->dim(1))) == $missing_val ) .= -1;
+    $dense_rc->where( $a->index2d($dense_rc,sequence($a->dim(1))) == $missing_val ) .= indx(-1);
   } elsif ($ufunc_name =~ /qsorti$/) {
     ##-- hack: adjust $dense_rc for qsorti()
     my $ccs_mask = $dense_rc->zeroes;
-    $ccs_mask->indexND( scalar($ccs_rc->whichND) ) .= 1;
+    $ccs_mask->indexND( scalar($ccs_rc->whichND) ) .= indx(1);
     $dense_rc->where( $ccs_mask->not ) .= $ccs_rc->missing;
   }
   my $label = "${ufunc_name}:missing=$missing_val";


### PR DESCRIPTION
As part of fixing the problem discussed in the second section of https://pdl.perl.org/advent/blog/2024/12/20/pdl-internals/, I made PDL reject assigning into a slice with the output of a type-conversion. That includes the code tweaked here.

As you can see at the bottom of that article, and in https://github.com/PDLPorters/pdl/issues/511, I'm probably going to take a different route to fixing the problem. But because this change here will reduce type-conversions, I felt it worth submitting anyway.

If you like it, please could you merge and release it quite soon? That would help me.